### PR TITLE
Fix `[compat]` entries in `Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ Multisets = "3b2b4ff1-bcff-5658-a3ee-dbcf1ce5ac09"
 julia = "1.4"
 Polynomials = "1"
 Mods = "1"
-Primes = "0"
-Multisets = "0"
+Primes = "0.4, 0.5"
+Multisets = "0.2, 0.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
In the General registry, we now **strongly** discourage users from having `[compat]` entries of the form:
```toml
SomePackage = "0"
```

These `[compat]` entries are problematic because they include an infinite number of breaking releases.

This pull request fixes the `[compat]` entries in the `Project.toml` file for this package.

cc: @scheinerman